### PR TITLE
feat: 接入文章搜索框与标签系统

### DIFF
--- a/pages/src/components/Card.tsx
+++ b/pages/src/components/Card.tsx
@@ -104,6 +104,16 @@ export default function Card({ id, href, frontmatter, secHeading = true, body, p
         </div>
         {/* <Datetime pubDatetime={pubDatetime} modDatetime={modDatetime} /> */}
       </div>
+      {id && (
+        <div className="-mt-1 mb-2 ms-8">
+          <a
+            href={`/tags/${id.split('/')[0].toLowerCase()}/`}
+            className="inline-block text-xs text-skin-base opacity-75 underline decoration-dashed underline-offset-2 hover:text-skin-accent hover:opacity-100"
+          >
+            #{id.split('/')[0]}
+          </a>
+        </div>
+      )}
       {publishCard &&
       // 去掉段后间隔，设置max-width为100%
         <div className="break-all prose" style={{maxWidth: "100%"}} >

--- a/pages/src/components/Header.astro
+++ b/pages/src/components/Header.astro
@@ -1,6 +1,7 @@
 ---
 import { LOGO_IMAGE, SITE } from "@config";
 import Hr from "./Hr.astro";
+import LinkButton from "./LinkButton.astro";
 
 export interface Props {
   activeNav?: "posts" | "tags" | "about" | "search" | "rank" | "tasks" | "wiki";
@@ -55,13 +56,16 @@ const { activeNav } = Astro.props;
         </button>
         <ul id="menu-items" class="display-none sm:flex">
           <li>
-            <a href="/" class={activeNav === "posts" ? "active" : ""}>
-              文章
-            </a>
+            <a href="/" class={activeNav === "posts" ? "active" : ""}> 文章 </a>
           </li>
           <li>
             <a href="/collected/" class={activeNav === "tasks" ? "active" : ""}>
               任务
+            </a>
+          </li>
+          <li>
+            <a href="/tags/" class={activeNav === "tags" ? "active" : ""}>
+              标签
             </a>
           </li>
           <li>
@@ -80,19 +84,30 @@ const { activeNav } = Astro.props;
             </a>
           </li>
           <li>
-            <a href="https://github.com/hust-open-atom-club/TranslateProject" class="align-bottom">
+            <a
+              href="https://github.com/hust-open-atom-club/TranslateProject"
+              class="align-bottom"
+            >
               Github
-              <svg aria-hidden="true" viewBox="0 -4 40 40" class="iconExternalLink_nPIU"><path fill="currentColor" d="M21 13v10h-21v-19h12v2h-10v15h17v-8h2zm3-12h-10.988l4.035 4-6.977 7.07 2.828 2.828 6.977-7.07 4.125 4.172v-11z"></path></svg>
+              <svg
+                aria-hidden="true"
+                viewBox="0 -4 40 40"
+                class="iconExternalLink_nPIU"
+                ><path
+                  fill="currentColor"
+                  d="M21 13v10h-21v-19h12v2h-10v15h17v-8h2zm3-12h-10.988l4.035 4-6.977 7.07 2.828 2.828 6.977-7.07 4.125 4.172v-11z"
+                ></path></svg
+              >
             </a>
           </li>
-          <!-- <li>
+          <li>
             <LinkButton
               href="/search/"
               className={`focus-outline p-3 sm:p-1 ${
                 activeNav === "search" ? "active" : ""
               } flex`}
               ariaLabel="search"
-              title="Search"
+              title="搜索"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -101,9 +116,9 @@ const { activeNav } = Astro.props;
                   d="M19.023 16.977a35.13 35.13 0 0 1-1.367-1.384c-.372-.378-.596-.653-.596-.653l-2.8-1.337A6.962 6.962 0 0 0 16 9c0-3.859-3.14-7-7-7S2 5.141 2 9s3.14 7 7 7c1.763 0 3.37-.66 4.603-1.739l1.337 2.8s.275.224.653.596c.387.363.896.854 1.384 1.367l1.358 1.392.604.646 2.121-2.121-.646-.604c-.379-.372-.885-.866-1.391-1.36zM9 14c-2.757 0-5-2.243-5-5s2.243-5 5-5 5 2.243 5 5-2.243 5-5 5z"
                 ></path>
               </svg>
-              <span class="sr-only">Search</span>
+              <span class="sr-only">搜索</span>
             </LinkButton>
-          </li> -->
+          </li>
           {
             SITE.lightAndDarkMode && (
               <li>

--- a/pages/src/components/Search.tsx
+++ b/pages/src/components/Search.tsx
@@ -80,14 +80,14 @@ export default function SearchBar({ searchList }: Props) {
           <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
             <path d="M19.023 16.977a35.13 35.13 0 0 1-1.367-1.384c-.372-.378-.596-.653-.596-.653l-2.8-1.337A6.962 6.962 0 0 0 16 9c0-3.859-3.14-7-7-7S2 5.141 2 9s3.14 7 7 7c1.763 0 3.37-.66 4.603-1.739l1.337 2.8s.275.224.653.596c.387.363.896.854 1.384 1.367l1.358 1.392.604.646 2.121-2.121-.646-.604c-.379-.372-.885-.866-1.391-1.36zM9 14c-2.757 0-5-2.243-5-5s2.243-5 5-5 5 2.243 5 5-2.243 5-5 5z"></path>
           </svg>
-          <span className="sr-only">Search</span>
+          <span className="sr-only">搜索</span>
         </span>
         <input
-          className="block w-full rounded border border-skin-fill 
+          className="block w-full rounded border border-skin-fill
         border-opacity-40 bg-skin-fill py-3 pl-10
-        pr-3 placeholder:italic placeholder:text-opacity-75 
+        pr-3 placeholder:italic placeholder:text-opacity-75
         focus:border-skin-accent focus:outline-none"
-          placeholder="Search for anything..."
+          placeholder="输入关键词搜索标题或摘要…"
           type="text"
           name="search"
           value={inputVal}
@@ -100,11 +100,7 @@ export default function SearchBar({ searchList }: Props) {
 
       {inputVal.length > 1 && (
         <div className="mt-8">
-          Found {searchResults?.length}
-          {searchResults?.length && searchResults?.length === 1
-            ? " result"
-            : " results"}{" "}
-          for '{inputVal}'
+          找到 {searchResults?.length ?? 0} 条与「{inputVal}」相关的结果
         </div>
       )}
 
@@ -112,6 +108,7 @@ export default function SearchBar({ searchList }: Props) {
         {searchResults &&
           searchResults.map(({ item, refIndex }) => (
             <Card
+              id={item.slug}
               href={`/posts/${item.slug}/`}
               frontmatter={item.data}
               key={`${refIndex}-${item.slug}`}

--- a/pages/src/pages/search.astro
+++ b/pages/src/pages/search.astro
@@ -1,0 +1,26 @@
+---
+import { getCollection } from "astro:content";
+import Layout from "@layouts/Layout.astro";
+import Main from "@layouts/Main.astro";
+import Header from "@components/Header.astro";
+import Footer from "@components/Footer.astro";
+import SearchBar from "@components/Search";
+import { SITE } from "@config";
+
+const posts = await getCollection("posts");
+
+const searchList = posts.map(({ data, slug, body }) => ({
+  title: data.title,
+  description: body.replace(/[#`*>-]/g, "").slice(0, 200),
+  data,
+  slug,
+}));
+---
+
+<Layout title={`搜索 | ${SITE.title}`}>
+  <Header activeNav="search" />
+  <Main pageTitle="搜索" pageDesc="按关键词检索文章标题或正文摘要。">
+    <SearchBar client:load searchList={searchList} />
+  </Main>
+  <Footer />
+</Layout>

--- a/pages/src/pages/tags/[tag]/[page].astro
+++ b/pages/src/pages/tags/[tag]/[page].astro
@@ -1,0 +1,34 @@
+---
+import type { GetStaticPaths } from "astro";
+import { getCollection } from "astro:content";
+import TagPosts from "@layouts/TagPosts.astro";
+import getPagination from "@utils/getPagination";
+import getPageNumbers from "@utils/getPageNumbers";
+import { getUniqueTags, getPostsByTag } from "@utils/getTagsFromPosts";
+
+export const getStaticPaths = (async () => {
+  const posts = await getCollection("posts");
+  const ret: { params: { tag: string; page: string } }[] = [];
+
+  for (const { tag } of getUniqueTags(posts)) {
+    const tagPosts = getPostsByTag(posts, tag);
+    const pagePaths = getPageNumbers(tagPosts.length).map(pageNum => ({
+      params: { tag, page: pageNum.toString() },
+    }));
+    ret.push(...pagePaths);
+  }
+  return ret;
+}) satisfies GetStaticPaths;
+
+const { tag, page } = Astro.params;
+const posts = await getCollection("posts");
+const tagPosts = getPostsByTag(posts, tag);
+
+const pagination = getPagination({
+  posts: tagPosts,
+  page: parseInt(page),
+  isIndex: false,
+});
+---
+
+<TagPosts {...pagination} tag={tag} tagName={tag} />

--- a/pages/src/pages/tags/[tag]/index.astro
+++ b/pages/src/pages/tags/[tag]/index.astro
@@ -1,0 +1,26 @@
+---
+import type { GetStaticPaths } from "astro";
+import { getCollection } from "astro:content";
+import TagPosts from "@layouts/TagPosts.astro";
+import getPagination from "@utils/getPagination";
+import { getUniqueTags, getPostsByTag } from "@utils/getTagsFromPosts";
+
+export const getStaticPaths = (async () => {
+  const posts = await getCollection("posts");
+  return getUniqueTags(posts).map(({ tag }) => ({
+    params: { tag },
+  }));
+}) satisfies GetStaticPaths;
+
+const { tag } = Astro.params;
+const posts = await getCollection("posts");
+const tagPosts = getPostsByTag(posts, tag);
+
+const pagination = getPagination({
+  posts: tagPosts,
+  page: 1,
+  isIndex: true,
+});
+---
+
+<TagPosts {...pagination} tag={tag} tagName={tag} />

--- a/pages/src/pages/tags/index.astro
+++ b/pages/src/pages/tags/index.astro
@@ -1,0 +1,30 @@
+---
+import { getCollection } from "astro:content";
+import Layout from "@layouts/Layout.astro";
+import Main from "@layouts/Main.astro";
+import Header from "@components/Header.astro";
+import Footer from "@components/Footer.astro";
+import Tag from "@components/Tag.astro";
+import { getUniqueTags } from "@utils/getTagsFromPosts";
+import { SITE } from "@config";
+
+const posts = await getCollection("posts");
+const tags = getUniqueTags(posts);
+---
+
+<Layout title={`标签 | ${SITE.title}`}>
+  <Header activeNav="tags" />
+  <Main pageTitle="标签" pageDesc="按主题快速筛选文章。">
+    <ul>
+      {
+        tags.map(({ tag, count }) => (
+          <div class="flex items-baseline">
+            <Tag tag={tag} size="lg" />
+            <span class="ml-1 text-sm opacity-75">({count})</span>
+          </div>
+        ))
+      }
+    </ul>
+  </Main>
+  <Footer />
+</Layout>

--- a/pages/src/utils/getTagsFromPosts.ts
+++ b/pages/src/utils/getTagsFromPosts.ts
@@ -1,0 +1,33 @@
+import type { CollectionEntry } from "astro:content";
+import getSortedPosts from "./getSortedPosts";
+
+export const getTagFromSlug = (slug: string): string => {
+  return slug.split("/")[0] || "";
+};
+
+export interface TagWithCount {
+  tag: string;
+  count: number;
+}
+
+export const getUniqueTags = (
+  posts: CollectionEntry<"posts">[]
+): TagWithCount[] => {
+  const counter = new Map<string, number>();
+  for (const post of posts) {
+    const tag = getTagFromSlug(post.slug);
+    if (!tag) continue;
+    counter.set(tag, (counter.get(tag) || 0) + 1);
+  }
+  return Array.from(counter.entries())
+    .map(([tag, count]) => ({ tag, count }))
+    .sort((a, b) => b.count - a.count);
+};
+
+export const getPostsByTag = (
+  posts: CollectionEntry<"posts">[],
+  tag: string
+): CollectionEntry<"posts">[] => {
+  const filtered = posts.filter(post => getTagFromSlug(post.slug) === tag);
+  return getSortedPosts(filtered);
+};


### PR DESCRIPTION
## 动机

随着译文增多（当前 193 篇），仅按时间排序的列表让读者难以按主题（如 Kernel、LLVM、Syzkaller）快速定位内容。

## 改动概览

复用 AstroPaper 模板**已存在但未启用**的组件（`Search.tsx`、`Tag.astro`、`TagPosts.astro`），补上路由和站点入口，最小侵入实现：

1. **搜索**：新 `/search/` 路由 + 顶部导航搜索按钮（启用既有但被注释的入口）。基于 fuse.js 模糊匹配文章标题与正文摘要（取每篇 body 前 200 字）。
2. **标签**：新 `/tags/` 路由列出全部标签 + 文章数；`/tags/{tag}/` 按标签筛选并分页。
3. **标签来源**：从 `sources/` 一级目录自动派生（`syzkaller/foo.md` → tag = `syzkaller`），**不修改 frontmatter**，零迁移。当前自动得到 7 个标签：`aflplusplus / general / GhidraDocs / kernel / llvm / OSPO-101 / syzkaller`。
4. **Card 徽章**：每张文章卡片标题下方显示 `#标签` 链接，点击进入对应标签页。
5. **Search 组件中文化**：placeholder、计数文案、aria 文本与站点其余部分保持中文一致。

## 文件变动

**新增**
- `pages/src/utils/getTagsFromPosts.ts`
- `pages/src/pages/search.astro`
- `pages/src/pages/tags/index.astro`
- `pages/src/pages/tags/[tag]/index.astro`
- `pages/src/pages/tags/[tag]/[page].astro`

**修改**
- `pages/src/components/Card.tsx`（标签徽章，10 行新增）
- `pages/src/components/Header.astro`（启用搜索按钮 + 加"标签"链接）
- `pages/src/components/Search.tsx`（中文文案 + 透传 id）

## 验证

- `npm run build` 通过：240 页（含新增 search + 7 个 tag 子页 + 各 tag 分页）
- 本地 `npm run dev`：
  - `/search/` 输入关键词可实时返回匹配
  - `/tags/` 列出 7 个标签和计数
  - `/tags/kernel/` 等标签页显示对应文章并分页正常
  - 首页 Card 下出现 `#tag` 链接，点击跳转至该标签页
- `npm run lint`：本 PR 涉及文件无新增 lint 错误（仓库存量错误未触碰）
- prettier：本 PR 涉及文件均已通过 `prettier --check`

## 备注

- 标签 URL 统一小写（与 Astro content collection slug 行为对齐），徽章显示文本保留原大小写（贴近源目录命名）
- `Card` 改动严格限定为新增标签徽章块，未做无关重排，diff 干净
- 这是个人为练习 GitHub 贡献流程而提交的 PR；CLA 暂未签署，maintainer 自行决定是否处理。无论合并与否都已感谢 review

🤖 实现配合 [Claude Code](https://claude.com/claude-code) 完成