### PR TITLE
feat(pages): 接入文章搜索框与标签系统（重做 #367）

### DIFF
--- a/pages/src/components/Card.tsx
+++ b/pages/src/components/Card.tsx
@@ -1,38 +1,49 @@
 import { STATUS_LIST } from "@config";
 import { slugifyStr } from "@utils/slugify";
 import type { CollectionEntry } from "astro:content";
-import { marked } from 'marked';
+import { marked } from "marked";
 import truncate from "html-truncator";
 
 // 定义一个函数，解析body为markdown格式，然后去掉解析出来的所有h标签元素
 const parseBody = (body: string, href: string) => {
   let marked_content = marked(body.substring(0, 1000)); // 避免过长的解析
   // check type of marked_content
-  if (typeof marked_content !== 'string') {
-    return body.substring(0, 130) + "……&nbsp&nbsp<a href={" + href + "}>[阅读更多]</a>";
+  if (typeof marked_content !== "string") {
+    return (
+      body.substring(0, 130) +
+      "……&nbsp&nbsp<a href={" +
+      href +
+      "}>[阅读更多]</a>"
+    );
   }
   // remove h1
-  marked_content = marked_content.replace(/<h..*?>.*?<\/h.>/g, '');
+  marked_content = marked_content.replace(/<h..*?>.*?<\/h.>/g, "");
   // remove img
-  marked_content = marked_content.replace(/<img.*?>/g, '');
+  marked_content = marked_content.replace(/<img.*?>/g, "");
   // limit shown content length, but keep the html tags which are not closed
   marked_content = truncate(marked_content, 130);
   // default end is '...', remove it
   marked_content = marked_content.replace(/\.\.\.$/, "");
   // get the last tag of the content
-  let lastTag = marked_content.lastIndexOf('<');
+  let lastTag = marked_content.lastIndexOf("<");
   // record the last tag
   let lastTagContent = marked_content.substring(lastTag);
   // remove the last tag
   marked_content = marked_content.substring(0, lastTag);
   let end = "……&nbsp&nbsp<a href=" + href + ">[阅读更多]</a>" + lastTagContent;
   return marked_content + end;
-}
+};
 
 // 定义一个函数，解析20240428格式为2024-04-28
 const parseDate = (date: string) => {
-  return date.substring(0, 4) + "-" + date.substring(4, 6) + "-" + date.substring(6, 8);
-}
+  return (
+    date.substring(0, 4) +
+    "-" +
+    date.substring(4, 6) +
+    "-" +
+    date.substring(6, 8)
+  );
+};
 
 export interface Props {
   id?: string;
@@ -43,14 +54,15 @@ export interface Props {
   publishCard?: boolean;
 }
 
-export default function Card({ id, href, frontmatter, secHeading = true, body, publishCard }: Props) {
-  const {
-    title,
-    status,
-    translator,
-    published_date,
-    priority
-  } = frontmatter;
+export default function Card({
+  id,
+  href,
+  frontmatter,
+  secHeading = true,
+  body,
+  publishCard,
+}: Props) {
+  const { title, status, translator, published_date, priority } = frontmatter;
 
   const headerProps = {
     style: { viewTransitionName: slugifyStr(id || title) },
@@ -58,7 +70,7 @@ export default function Card({ id, href, frontmatter, secHeading = true, body, p
   };
 
   return (
-    <li className={publishCard ? "mb-8" : ""} >
+    <li className={publishCard ? "mb-8" : ""}>
       <div className="my-2 flex flex-row">
         <a
           href={href}
@@ -67,77 +79,110 @@ export default function Card({ id, href, frontmatter, secHeading = true, body, p
           {secHeading ? (
             id ? (
               <h2 {...headerProps}>
-                <img className="inline-block w-6 h-6 me-2" src={"/assets/logo_" + id.split('/')[0] + ".png"} alt={id.split('/')[0] + " icon"} />
+                <img
+                  className="inline-block w-6 h-6 me-2"
+                  src={"/assets/logo_" + id.split("/")[0] + ".png"}
+                  alt={id.split("/")[0] + " icon"}
+                />
                 {/* 如果有priority属性则增加一个红色感叹号 */}
-                {priority ? <svg viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" p-id="1372"><path d="M512 768c72.533333 0 128 55.466667 128 128s-55.466667 128-128 128-128-55.466667-128-128 55.466667-128 128-128z m0-768c68.266667 0 119.466667 55.466667 119.466667 119.466667V128l-29.866667 469.333333c-4.266667 46.933333-42.666667 85.333333-89.6 85.333334s-89.6-38.4-89.6-85.333334L392.533333 128c-4.266667-68.266667 46.933333-123.733333 110.933334-128h8.533333z" fill="#E63C28" p-id="1373"></path></svg> : null}
+                {priority ? (
+                  <svg
+                    viewBox="0 0 1024 1024"
+                    version="1.1"
+                    xmlns="http://www.w3.org/2000/svg"
+                    p-id="1372"
+                  >
+                    <path
+                      d="M512 768c72.533333 0 128 55.466667 128 128s-55.466667 128-128 128-128-55.466667-128-128 55.466667-128 128-128z m0-768c68.266667 0 119.466667 55.466667 119.466667 119.466667V128l-29.866667 469.333333c-4.266667 46.933333-42.666667 85.333333-89.6 85.333334s-89.6-38.4-89.6-85.333334L392.533333 128c-4.266667-68.266667 46.933333-123.733333 110.933334-128h8.533333z"
+                      fill="#E63C28"
+                      p-id="1373"
+                    ></path>
+                  </svg>
+                ) : null}
                 {title}
               </h2>
             ) : (
               <h2 {...headerProps}>{title}</h2>
             )
+          ) : id ? (
+            <h3 {...headerProps}>
+              <img
+                className="inline-block w-6 h-6 me-2"
+                src={"/assets/logo_" + id.split("/")[0] + ".png"}
+                alt={id.split("/")[0] + " icon"}
+              />
+              {title}
+            </h3>
           ) : (
-            id ? (
-              <h3 {...headerProps}>
-                <img className="inline-block w-6 h-6 me-2" src={"/assets/logo_" + id.split('/')[0] + ".png"} alt={id.split('/')[0] + " icon"} />
-                {title}
-              </h3>
-            ) : (
-              <h3 {...headerProps}>{title}</h3>
-            )
+            <h3 {...headerProps}>{title}</h3>
           )}
         </a>
-        {
-          publishCard && <p {...headerProps}>{parseDate(published_date.toString())}</p>
-        }
-        {
-          status === 'collected' && <div className="px-2 mx-2 text-slate-500">
+        {publishCard && (
+          <p {...headerProps}>{parseDate(published_date.toString())}</p>
+        )}
+        {status === "collected" && (
+          <div className="px-2 mx-2 text-slate-500">
             {body && body.split(/\s/g).length} 词
           </div>
-        }
-        {
-          status === 'translating' && <div className="px-2 mx-2 text-slate-500">
-            {translator}
-          </div>
-        }
-        <div>
-          {!publishCard && <Status status={status} id={id} />}
-        </div>
+        )}
+        {status === "translating" && (
+          <div className="px-2 mx-2 text-slate-500">{translator}</div>
+        )}
+        <div>{!publishCard && <Status status={status} id={id} />}</div>
         {/* <Datetime pubDatetime={pubDatetime} modDatetime={modDatetime} /> */}
       </div>
-      {publishCard &&
-      // 去掉段后间隔，设置max-width为100%
-        <div className="break-all prose" style={{maxWidth: "100%"}} >
-          {/* 注意需要my-0否则继承 */}
-          <p className="my-0" dangerouslySetInnerHTML={{
-            __html: parseBody(body || "", href || "") }} >
-              </p>
-          
+      {id && (
+        // 标签徽章：显示保留 sources/ 一级目录原大小写（如 GhidraDocs），
+        // URL 走小写以匹配 /tags/[tag]/ 路由（与 Tag.astro 行为一致）。
+        <div className="-mt-1 mb-2 ms-8">
+          <a
+            href={`/tags/${id.split("/")[0].toLowerCase()}/`}
+            className="inline-block text-xs text-skin-base opacity-75 underline decoration-dashed underline-offset-2 hover:text-skin-accent hover:opacity-100"
+          >
+            #{id.split("/")[0]}
+          </a>
         </div>
-      }
-      {
-        publishCard && <hr className="my-4 border-skin-lightline" />
-      }
+      )}
+      {publishCard && (
+        // 去掉段后间隔，设置max-width为100%
+        <div className="break-all prose" style={{ maxWidth: "100%" }}>
+          {/* 注意需要my-0否则继承 */}
+          <p
+            className="my-0"
+            dangerouslySetInnerHTML={{
+              __html: parseBody(body || "", href || ""),
+            }}
+          ></p>
+        </div>
+      )}
+      {publishCard && <hr className="my-4 border-skin-lightline" />}
     </li>
   );
 }
 
-function Status({ status, id }: { status: string, id: string | undefined }) {
+function Status({ status, id }: { status: string; id: string | undefined }) {
   const getStyle = (status: string) => {
     var s = STATUS_LIST.find(s => s.status === status);
     if (s) return s.color;
     else return "bg-gray-200";
-  }
+  };
 
   const getText = (status: string) => {
     var s = STATUS_LIST.find(s => s.status === status);
     if (s) return s.text;
     else return status;
-  }
+  };
 
-  if (status === 'collected' || status === 'translated' || status === 'proofread') {
+  if (
+    status === "collected" ||
+    status === "translated" ||
+    status === "proofread"
+  ) {
     return (
       <span className="flex flex-row items-center">
-        <span className={`flex w-3 h-3 me-3 ${getStyle(status)} rounded-full`}></span>
+        <span
+          className={`flex w-3 h-3 me-3 ${getStyle(status)} rounded-full`}
+        ></span>
         <span>
           <a
             href={`https://github.com/hust-open-atom-club/TranslateProject/edit/master/sources/${id}`}
@@ -147,16 +192,15 @@ function Status({ status, id }: { status: string, id: string | undefined }) {
           </a>
         </span>
       </span>
-    )
-  }
-  else {
+    );
+  } else {
     return (
       <span className="flex flex-row items-center">
-        <span className={`flex w-3 h-3 me-3 ${getStyle(status)} rounded-full`}></span>
-        <span>
-          {getText(status)}
-        </span>
+        <span
+          className={`flex w-3 h-3 me-3 ${getStyle(status)} rounded-full`}
+        ></span>
+        <span>{getText(status)}</span>
       </span>
-    )
+    );
   }
 }

--- a/pages/src/components/Header.astro
+++ b/pages/src/components/Header.astro
@@ -1,6 +1,7 @@
 ---
 import { LOGO_IMAGE, SITE } from "@config";
 import Hr from "./Hr.astro";
+import LinkButton from "./LinkButton.astro";
 
 export interface Props {
   activeNav?: "posts" | "tags" | "about" | "search" | "rank" | "tasks" | "wiki";
@@ -55,13 +56,16 @@ const { activeNav } = Astro.props;
         </button>
         <ul id="menu-items" class="display-none sm:flex">
           <li>
-            <a href="/" class={activeNav === "posts" ? "active" : ""}>
-              文章
-            </a>
+            <a href="/" class={activeNav === "posts" ? "active" : ""}> 文章 </a>
           </li>
           <li>
             <a href="/collected/" class={activeNav === "tasks" ? "active" : ""}>
               任务
+            </a>
+          </li>
+          <li>
+            <a href="/tags/" class={activeNav === "tags" ? "active" : ""}>
+              标签
             </a>
           </li>
           <li>
@@ -70,7 +74,10 @@ const { activeNav } = Astro.props;
             </a>
           </li>
           <li>
-            <a href="https://github.com/hust-open-atom-club/TranslateProject/wiki" class={activeNav === "wiki" ? "active" : ""}>
+            <a
+              href="https://github.com/hust-open-atom-club/TranslateProject/wiki"
+              class={activeNav === "wiki" ? "active" : ""}
+            >
               Wiki
             </a>
           </li>
@@ -80,19 +87,30 @@ const { activeNav } = Astro.props;
             </a>
           </li>
           <li>
-            <a href="https://github.com/hust-open-atom-club/TranslateProject" class="align-bottom">
+            <a
+              href="https://github.com/hust-open-atom-club/TranslateProject"
+              class="align-bottom"
+            >
               Github
-              <svg aria-hidden="true" viewBox="0 -4 40 40" class="iconExternalLink_nPIU"><path fill="currentColor" d="M21 13v10h-21v-19h12v2h-10v15h17v-8h2zm3-12h-10.988l4.035 4-6.977 7.07 2.828 2.828 6.977-7.07 4.125 4.172v-11z"></path></svg>
+              <svg
+                aria-hidden="true"
+                viewBox="0 -4 40 40"
+                class="iconExternalLink_nPIU"
+                ><path
+                  fill="currentColor"
+                  d="M21 13v10h-21v-19h12v2h-10v15h17v-8h2zm3-12h-10.988l4.035 4-6.977 7.07 2.828 2.828 6.977-7.07 4.125 4.172v-11z"
+                ></path></svg
+              >
             </a>
           </li>
-          <!-- <li>
+          <li>
             <LinkButton
               href="/search/"
               className={`focus-outline p-3 sm:p-1 ${
                 activeNav === "search" ? "active" : ""
               } flex`}
               ariaLabel="search"
-              title="Search"
+              title="搜索"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -101,9 +119,9 @@ const { activeNav } = Astro.props;
                   d="M19.023 16.977a35.13 35.13 0 0 1-1.367-1.384c-.372-.378-.596-.653-.596-.653l-2.8-1.337A6.962 6.962 0 0 0 16 9c0-3.859-3.14-7-7-7S2 5.141 2 9s3.14 7 7 7c1.763 0 3.37-.66 4.603-1.739l1.337 2.8s.275.224.653.596c.387.363.896.854 1.384 1.367l1.358 1.392.604.646 2.121-2.121-.646-.604c-.379-.372-.885-.866-1.391-1.36zM9 14c-2.757 0-5-2.243-5-5s2.243-5 5-5 5 2.243 5 5-2.243 5-5 5z"
                 ></path>
               </svg>
-              <span class="sr-only">Search</span>
+              <span class="sr-only">搜索</span>
             </LinkButton>
-          </li> -->
+          </li>
           {
             SITE.lightAndDarkMode && (
               <li>

--- a/pages/src/components/Search.tsx
+++ b/pages/src/components/Search.tsx
@@ -8,6 +8,10 @@ export type SearchItem = {
   description: string;
   data: CollectionEntry<"posts">["data"];
   slug: string;
+  // The original content-collection entry id (e.g. "kernel/foo.md").
+  // Card 通过它派生 logo / GitHub edit 链接 / 标签徽章；slug 仅用于 URL 路由。
+  // 不要用 slug 替代 id，否则 Card 内部 `sources/${id}` 会拼出 404。
+  entryId: string;
 };
 
 interface Props {
@@ -80,14 +84,14 @@ export default function SearchBar({ searchList }: Props) {
           <svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
             <path d="M19.023 16.977a35.13 35.13 0 0 1-1.367-1.384c-.372-.378-.596-.653-.596-.653l-2.8-1.337A6.962 6.962 0 0 0 16 9c0-3.859-3.14-7-7-7S2 5.141 2 9s3.14 7 7 7c1.763 0 3.37-.66 4.603-1.739l1.337 2.8s.275.224.653.596c.387.363.896.854 1.384 1.367l1.358 1.392.604.646 2.121-2.121-.646-.604c-.379-.372-.885-.866-1.391-1.36zM9 14c-2.757 0-5-2.243-5-5s2.243-5 5-5 5 2.243 5 5-2.243 5-5 5z"></path>
           </svg>
-          <span className="sr-only">Search</span>
+          <span className="sr-only">搜索</span>
         </span>
         <input
           className="block w-full rounded border border-skin-fill 
         border-opacity-40 bg-skin-fill py-3 pl-10
         pr-3 placeholder:italic placeholder:text-opacity-75 
         focus:border-skin-accent focus:outline-none"
-          placeholder="Search for anything..."
+          placeholder="按关键词检索文章..."
           type="text"
           name="search"
           value={inputVal}
@@ -100,11 +104,7 @@ export default function SearchBar({ searchList }: Props) {
 
       {inputVal.length > 1 && (
         <div className="mt-8">
-          Found {searchResults?.length}
-          {searchResults?.length && searchResults?.length === 1
-            ? " result"
-            : " results"}{" "}
-          for '{inputVal}'
+          找到 {searchResults?.length ?? 0} 条与「{inputVal}」相关的结果
         </div>
       )}
 
@@ -112,6 +112,7 @@ export default function SearchBar({ searchList }: Props) {
         {searchResults &&
           searchResults.map(({ item, refIndex }) => (
             <Card
+              id={item.entryId}
               href={`/posts/${item.slug}/`}
               frontmatter={item.data}
               key={`${refIndex}-${item.slug}`}

--- a/pages/src/components/Tag.astro
+++ b/pages/src/components/Tag.astro
@@ -2,9 +2,11 @@
 export interface Props {
   tag: string;
   size?: "sm" | "lg";
+  // 可选：在标签名后附加文章计数（用于 /tags/ 索引页）。
+  count?: number;
 }
 
-const { tag, size = "sm" } = Astro.props;
+const { tag, size = "sm", count } = Astro.props;
 ---
 
 <li
@@ -25,6 +27,11 @@ const { tag, size = "sm" } = Astro.props;
       ></path>
     </svg>
     &nbsp;<span>{tag}</span>
+    {
+      count !== undefined && (
+        <span class="ml-1 text-sm opacity-75">({count})</span>
+      )
+    }
   </a>
 </li>
 

--- a/pages/src/pages/search.astro
+++ b/pages/src/pages/search.astro
@@ -1,0 +1,29 @@
+---
+import { getCollection } from "astro:content";
+import Layout from "@layouts/Layout.astro";
+import Main from "@layouts/Main.astro";
+import Header from "@components/Header.astro";
+import Footer from "@components/Footer.astro";
+import SearchBar from "@components/Search";
+import { SITE } from "@config";
+
+const posts = await getCollection("posts");
+
+const searchList = posts.map(({ id, data, slug, body }) => ({
+  title: data.title,
+  description: body.replace(/[#`*>-]/g, "").slice(0, 200),
+  data,
+  slug,
+  // entry.id 保留 .md 后缀和原大小写，与 Posts.astro 给 Card 的 id={id}
+  // 行为一致；slug 仅用于 URL 路由（小写、无后缀）。
+  entryId: id,
+}));
+---
+
+<Layout title={`搜索 | ${SITE.title}`}>
+  <Header activeNav="search" />
+  <Main pageTitle="搜索" pageDesc="按关键词检索文章标题或正文摘要。">
+    <SearchBar client:load searchList={searchList} />
+  </Main>
+  <Footer />
+</Layout>

--- a/pages/src/pages/tags/[tag]/[page].astro
+++ b/pages/src/pages/tags/[tag]/[page].astro
@@ -1,0 +1,34 @@
+---
+import type { GetStaticPaths } from "astro";
+import { getCollection } from "astro:content";
+import TagPosts from "@layouts/TagPosts.astro";
+import getPagination from "@utils/getPagination";
+import getPageNumbers from "@utils/getPageNumbers";
+import { getUniqueTags, getPostsByTag } from "@utils/getTagsFromPosts";
+
+export const getStaticPaths = (async () => {
+  const posts = await getCollection("posts");
+  const ret: { params: { tag: string; page: string } }[] = [];
+
+  for (const { tag } of getUniqueTags(posts)) {
+    const tagPosts = getPostsByTag(posts, tag);
+    const pagePaths = getPageNumbers(tagPosts.length).map(pageNum => ({
+      params: { tag, page: pageNum.toString() },
+    }));
+    ret.push(...pagePaths);
+  }
+  return ret;
+}) satisfies GetStaticPaths;
+
+const { tag, page } = Astro.params;
+const posts = await getCollection("posts");
+const tagPosts = getPostsByTag(posts, tag);
+
+const pagination = getPagination({
+  posts: tagPosts,
+  page: parseInt(page),
+  isIndex: false,
+});
+---
+
+<TagPosts {...pagination} tag={tag} tagName={tag} />

--- a/pages/src/pages/tags/[tag]/index.astro
+++ b/pages/src/pages/tags/[tag]/index.astro
@@ -1,0 +1,26 @@
+---
+import type { GetStaticPaths } from "astro";
+import { getCollection } from "astro:content";
+import TagPosts from "@layouts/TagPosts.astro";
+import getPagination from "@utils/getPagination";
+import { getUniqueTags, getPostsByTag } from "@utils/getTagsFromPosts";
+
+export const getStaticPaths = (async () => {
+  const posts = await getCollection("posts");
+  return getUniqueTags(posts).map(({ tag }) => ({
+    params: { tag },
+  }));
+}) satisfies GetStaticPaths;
+
+const { tag } = Astro.params;
+const posts = await getCollection("posts");
+const tagPosts = getPostsByTag(posts, tag);
+
+const pagination = getPagination({
+  posts: tagPosts,
+  page: 1,
+  isIndex: true,
+});
+---
+
+<TagPosts {...pagination} tag={tag} tagName={tag} />

--- a/pages/src/pages/tags/index.astro
+++ b/pages/src/pages/tags/index.astro
@@ -1,0 +1,29 @@
+---
+import { getCollection } from "astro:content";
+import Layout from "@layouts/Layout.astro";
+import Main from "@layouts/Main.astro";
+import Header from "@components/Header.astro";
+import Footer from "@components/Footer.astro";
+import Tag from "@components/Tag.astro";
+import { getUniqueTags } from "@utils/getTagsFromPosts";
+import { SITE } from "@config";
+
+const posts = await getCollection("posts");
+const tags = getUniqueTags(posts);
+---
+
+<Layout title={`标签 | ${SITE.title}`}>
+  <Header activeNav="tags" />
+  <Main pageTitle="标签" pageDesc="按主题快速筛选文章。">
+    <ul>
+      {
+        tags.map(({ tag, count }) => (
+          // Tag.astro 渲染 <li>，外层只用 <ul> 直接套，避免无效的
+          // <ul><div><li>... 嵌套；计数用 data-attr 不另开包装层。
+          <Tag tag={tag} size="lg" count={count} />
+        ))
+      }
+    </ul>
+  </Main>
+  <Footer />
+</Layout>

--- a/pages/src/utils/getTagsFromPosts.ts
+++ b/pages/src/utils/getTagsFromPosts.ts
@@ -1,0 +1,33 @@
+import type { CollectionEntry } from "astro:content";
+import getSortedPosts from "./getSortedPosts";
+
+export const getTagFromSlug = (slug: string): string => {
+  return slug.split("/")[0] || "";
+};
+
+export interface TagWithCount {
+  tag: string;
+  count: number;
+}
+
+export const getUniqueTags = (
+  posts: CollectionEntry<"posts">[]
+): TagWithCount[] => {
+  const counter = new Map<string, number>();
+  for (const post of posts) {
+    const tag = getTagFromSlug(post.slug);
+    if (!tag) continue;
+    counter.set(tag, (counter.get(tag) || 0) + 1);
+  }
+  return Array.from(counter.entries())
+    .map(([tag, count]) => ({ tag, count }))
+    .sort((a, b) => b.count - a.count);
+};
+
+export const getPostsByTag = (
+  posts: CollectionEntry<"posts">[],
+  tag: string
+): CollectionEntry<"posts">[] => {
+  const filtered = posts.filter(post => getTagFromSlug(post.slug) === tag);
+  return getSortedPosts(filtered);
+};


### PR DESCRIPTION
> 此 PR 接替已关闭的 #367，针对该 PR 的 Copilot review 反馈以及自查发现的另外几处问题做了重写。CLA 已签署。

## 动机

随着译文增多（当前 193 篇），仅按时间排序让读者难以按主题（如 Kernel / LLVM / Syzkaller）快速定位内容。

## 改动概览

复用 AstroPaper 模板**已存在但未启用**的组件（`Search.tsx`、`Tag.astro`、`TagPosts.astro`），补上路由与站点入口，最小侵入实现：

1. **搜索**：新 `/search/` 路由 + 顶部导航搜索按钮（启用既有但被注释的入口）。基于 fuse.js 模糊匹配文章标题与正文摘要（取每篇 body 前 200 字）。
2. **标签**：新 `/tags/` 路由列出全部标签 + 文章数；`/tags/{tag}/` 按标签筛选并分页。
3. **标签来源**：从 `sources/` 一级目录自动派生（`syzkaller/foo.md` → tag = `syzkaller`），**不修改 frontmatter**，零迁移。当前自动得到 7 个标签：`aflplusplus / general / GhidraDocs / kernel / llvm / OSPO-101 / syzkaller`。
4. **Card 徽章**：每张文章卡片标题下方显示 `#标签` 链接，点击进入对应标签页。
5. **Search 组件中文化**：placeholder、计数文案、`title`、`sr-only` 与站点其余部分保持中文一致。

## 与 #367 的差异（这是为什么重做而不是 reopen）

#367 已被我自己关闭，且 fork 当时被删除，所以 head 分支在 GitHub 端不可恢复。新分支基于上游最新 `master`（commit `773e3e2`），相同 5 个语义 commit + 以下改进：

### 1. 修 #367 上 Copilot review 指出的 `id`/`slug` 语义混淆（高优先级）

`Card.tsx` 的 `id` prop 是复合契约：

| 派生用途 | 需求 |
|---|---|
| `Status` 组件拼 GitHub edit URL：`sources/${id}` | 大小写敏感、需要 `.md` 后缀 |
| logo 图标路径：`/assets/logo_${id.split('/')[0]}.png` | 大小写敏感（如 `logo_GhidraDocs.png`） |
| `viewTransitionName` slugify | 不敏感 |

#367 在搜索结果里把 `item.slug`（小写、无 `.md`）当 `id` 传 → 同时破坏前两个派生路径。本 PR 让 `SearchItem` 多带一个 `entryId` 字段持有 `entry.id`（保留大小写 + `.md`），`slug` 留作 URL 路由专用，Card 收到的契约不变。

### 2. 自查时另外修了 3 处 #367 没处理的问题

- **Search 组件 placeholder 仍是英文**：`"Search for anything..."` → `"按关键词检索文章..."`，`<span class="sr-only">Search</span>` → `搜索`。#367 的 PR body 自吹"中文化"但只改了结果计数。
- **`/tags/` 索引页 invalid HTML**：原来是 `<ul><div class="flex"><Tag/></div></ul>` 的结构——但 `Tag.astro` 内部已经渲染 `<li>`，`<ul>` 的合法 child 只能是 `<li>`/`<script>`/`<template>`。改用 `<ul>` 直接装 `<Tag>`，并给 `Tag.astro` 加可选 `count` prop 把计数挂在标签名后（不影响其他位置使用）。
- **徽章大小写不一致**：之前 search 结果卡片显示 `#ghidradocs`（小写）、主页卡片显示 `#GhidraDocs`（原大小写）。统一为：**显示文本保留原大小写**（与 `logo_GhidraDocs.png` 派生逻辑一致）、**URL 用小写**（与 `Tag.astro` 的 `/tags/${tag}/` 一致，因为 `getTagFromSlug` 取自小写 slug）。

## 文件变动

**新增**
- `pages/src/utils/getTagsFromPosts.ts`
- `pages/src/pages/search.astro`
- `pages/src/pages/tags/index.astro`
- `pages/src/pages/tags/[tag]/index.astro`
- `pages/src/pages/tags/[tag]/[page].astro`

**修改**
- `pages/src/components/Card.tsx`（标签徽章 +12 行实质新增；其余 diff 是 prettier --write 重排，建议 `git diff -w` 看清；详见 commit `16ebb74` 的 message）
- `pages/src/components/Header.astro`（启用搜索按钮 + 加"标签"链接）
- `pages/src/components/Search.tsx`（中文文案 + `entryId` 透传）
- `pages/src/components/Tag.astro`（新增可选 `count` prop，向后兼容）

## 验证

- `npx astro check` → **0 errors / 0 warnings / 11 hints**（hints 全部来自既有 `RankLayout.astro` / `PostDetails.astro` 的未用变量，与本 PR 无关）
- `npx astro build` → **223 page(s) built**，包含：
  - `/search/index.html`
  - `/tags/index.html`
  - 7 个标签子目录 `/tags/{aflplusplus,general,ghidradocs,kernel,llvm,ospo-101,syzkaller}/...`（**全小写 URL**）
  - 各 tag 分页路由
- `prettier --check` 涉及文件全绿
- `eslint`：仓库现有 eslint 配置对 TS/JSX 报 "Parsing error: Unexpected token {"，**这是仓库存量问题**（master baseline 的 `Card.tsx` 同样报错），本 PR 未引入新错误
- 视觉 sanity 检查：`grep` 编译产物确认徽章 URL 全小写、显示文本保留 `#GhidraDocs` / `#OSPO-101` 大小写

## AI 内容披露

本 PR 在 Claude Code 协助下完成。具体核查动作：

- **Copilot review 的 `id` vs `slug` 反馈**：在 `Posts.astro` / `admin.astro` / `translating.astro` grep `id={id}` 调用 + 阅读 `Card` 的 `Status` 子组件的 `sources/${id}` URL 拼接代码，独立确认 `id` 必须保留 `.md` 与大小写，再设计 `entryId` 字段方案
- **invalid HTML / 大小写不一致**：`grep -oE` 编译产物看徽章 HTML，从输出对照 `sources/` 目录 `ls` 验证大小写保留正确
- **变更影响面**：`grep -rn "<Card "` 全仓搜 Card 调用点，确认 `Tag.astro` 的 `count` 新增 prop 对其他位置无影响（其他调用点都不传 count）

## 备注

- 标签 URL 统一小写（与 Astro content collection slug 行为对齐），徽章显示文本保留原大小写（贴近源目录命名）。这两点不一致是有意为之，见 `Card.tsx` 行内注释。
- `Card` 改动严格限定为新增标签徽章 + prettier 重排，未做无关重构
- CLA 已签署
